### PR TITLE
Update metadata files to use new study name

### DIFF
--- a/experimentA/idr0045-experimentA-bulkmap-config.yml
+++ b/experimentA/idr0045-experimentA-bulkmap-config.yml
@@ -1,5 +1,5 @@
 ---
-name: idr0045-reichmann/experimentA
+name: idr0045-reichmann-zygotespindle/experimentA
 version: 1
 
 defaults:

--- a/idr0045-study.txt
+++ b/idr0045-study.txt
@@ -30,7 +30,7 @@ Study Data DOI	https://doi.org/10.17867/10000115
 				
 # EXPERIMENT SECTION				
 Experiment Number	1			
-Comment[IDR Experiment Name]	idr0045-reichmann/experimentA			
+Comment[IDR Experiment Name]	idr0045-reichmann-zygotespindle/experimentA			
 Experiment Description	Characterization of mitotic spindle formation in live mouse zygotes by light-sheet microscopy.			
 Experiment Size				
 Experiment Imaging Method	light sheet microscopy	confocal microscopy		

--- a/scripts/import/parallel_image_import.sh
+++ b/scripts/import/parallel_image_import.sh
@@ -28,7 +28,7 @@ $omero login
 expDir=`dirname $bulkFile`
 
 # Determine project directory and name
-projectName=idr0045-reichmann/experimentA 
+projectName=idr0045-reichmann-zygotespindle/experimentA
 
 # Determine path to filePaths.tsv
 filePaths=$expDir/`grep "path:" $bulkFile | cut -d " " -f2 | tr -d "\""`


### PR DESCRIPTION
Fixes #9 

- Updates the metadata files to match the new study name
- the repository has also been renamed as https://github.com/IDR/idr0045-reichmann-zygotespindle